### PR TITLE
Fix warning compilation message for unsigned long long variables

### DIFF
--- a/libviso2/libviso2/src/triangle.cpp
+++ b/libviso2/libviso2/src/triangle.cpp
@@ -1419,27 +1419,27 @@ void printtriangle(struct mesh *m, struct behavior *b, struct otri *t)
   struct osub printsh;
   vertex printvertex;
 
-  printf("triangle x%lx with orientation %d:\n", (unsigned long long) t->tri,
+  printf("triangle x%llx with orientation %d:\n", (unsigned long long) t->tri,
          t->orient);
   decode(t->tri[0], printtri);
   if (printtri.tri == m->dummytri) {
     printf("    [0] = Outer space\n");
   } else {
-    printf("    [0] = x%lx  %d\n", (unsigned long long) printtri.tri,
+    printf("    [0] = x%llx  %d\n", (unsigned long long) printtri.tri,
            printtri.orient);
   }
   decode(t->tri[1], printtri);
   if (printtri.tri == m->dummytri) {
     printf("    [1] = Outer space\n");
   } else {
-    printf("    [1] = x%lx  %d\n", (unsigned long long) printtri.tri,
+    printf("    [1] = x%llx  %d\n", (unsigned long long) printtri.tri,
            printtri.orient);
   }
   decode(t->tri[2], printtri);
   if (printtri.tri == m->dummytri) {
     printf("    [2] = Outer space\n");
   } else {
-    printf("    [2] = x%lx  %d\n", (unsigned long long) printtri.tri,
+    printf("    [2] = x%llx  %d\n", (unsigned long long) printtri.tri,
            printtri.orient);
   }
 
@@ -1447,38 +1447,38 @@ void printtriangle(struct mesh *m, struct behavior *b, struct otri *t)
   if (printvertex == (vertex) NULL)
     printf("    Origin[%d] = NULL\n", (t->orient + 1) % 3 + 3);
   else
-    printf("    Origin[%d] = x%lx  (%.12g, %.12g)\n",
+    printf("    Origin[%d] = x%llx  (%.12g, %.12g)\n",
            (t->orient + 1) % 3 + 3, (unsigned long long) printvertex,
            printvertex[0], printvertex[1]);
   dest(*t, printvertex);
   if (printvertex == (vertex) NULL)
     printf("    Dest  [%d] = NULL\n", (t->orient + 2) % 3 + 3);
   else
-    printf("    Dest  [%d] = x%lx  (%.12g, %.12g)\n",
+    printf("    Dest  [%d] = x%llx  (%.12g, %.12g)\n",
            (t->orient + 2) % 3 + 3, (unsigned long long) printvertex,
            printvertex[0], printvertex[1]);
   apex(*t, printvertex);
   if (printvertex == (vertex) NULL)
     printf("    Apex  [%d] = NULL\n", t->orient + 3);
   else
-    printf("    Apex  [%d] = x%lx  (%.12g, %.12g)\n",
+    printf("    Apex  [%d] = x%llx  (%.12g, %.12g)\n",
            t->orient + 3, (unsigned long long) printvertex,
            printvertex[0], printvertex[1]);
 
   if (b->usesegments) {
     sdecode(t->tri[6], printsh);
     if (printsh.ss != m->dummysub) {
-      printf("    [6] = x%lx  %d\n", (unsigned long long) printsh.ss,
+      printf("    [6] = x%llx  %d\n", (unsigned long long) printsh.ss,
              printsh.ssorient);
     }
     sdecode(t->tri[7], printsh);
     if (printsh.ss != m->dummysub) {
-      printf("    [7] = x%lx  %d\n", (unsigned long long) printsh.ss,
+      printf("    [7] = x%llx  %d\n", (unsigned long long) printsh.ss,
              printsh.ssorient);
     }
     sdecode(t->tri[8], printsh);
     if (printsh.ss != m->dummysub) {
-      printf("    [8] = x%lx  %d\n", (unsigned long long) printsh.ss,
+      printf("    [8] = x%llx  %d\n", (unsigned long long) printsh.ss,
              printsh.ssorient);
     }
   }
@@ -1505,20 +1505,20 @@ void printsubseg(struct mesh *m, struct behavior *b, struct osub *s)
   struct otri printtri;
   vertex printvertex;
 
-  printf("subsegment x%lx with orientation %d and mark %d:\n",
+  printf("subsegment x%llx with orientation %d and mark %d:\n",
          (unsigned long long) s->ss, s->ssorient, mark(*s));
   sdecode(s->ss[0], printsh);
   if (printsh.ss == m->dummysub) {
     printf("    [0] = No subsegment\n");
   } else {
-    printf("    [0] = x%lx  %d\n", (unsigned long long) printsh.ss,
+    printf("    [0] = x%llx  %d\n", (unsigned long long) printsh.ss,
            printsh.ssorient);
   }
   sdecode(s->ss[1], printsh);
   if (printsh.ss == m->dummysub) {
     printf("    [1] = No subsegment\n");
   } else {
-    printf("    [1] = x%lx  %d\n", (unsigned long long) printsh.ss,
+    printf("    [1] = x%llx  %d\n", (unsigned long long) printsh.ss,
            printsh.ssorient);
   }
 
@@ -1526,14 +1526,14 @@ void printsubseg(struct mesh *m, struct behavior *b, struct osub *s)
   if (printvertex == (vertex) NULL)
     printf("    Origin[%d] = NULL\n", 2 + s->ssorient);
   else
-    printf("    Origin[%d] = x%lx  (%.12g, %.12g)\n",
+    printf("    Origin[%d] = x%llx  (%.12g, %.12g)\n",
            2 + s->ssorient, (unsigned long long) printvertex,
            printvertex[0], printvertex[1]);
   sdest(*s, printvertex);
   if (printvertex == (vertex) NULL)
     printf("    Dest  [%d] = NULL\n", 3 - s->ssorient);
   else
-    printf("    Dest  [%d] = x%lx  (%.12g, %.12g)\n",
+    printf("    Dest  [%d] = x%llx  (%.12g, %.12g)\n",
            3 - s->ssorient, (unsigned long long) printvertex,
            printvertex[0], printvertex[1]);
 
@@ -1541,14 +1541,14 @@ void printsubseg(struct mesh *m, struct behavior *b, struct osub *s)
   if (printtri.tri == m->dummytri) {
     printf("    [6] = Outer space\n");
   } else {
-    printf("    [6] = x%lx  %d\n", (unsigned long long) printtri.tri,
+    printf("    [6] = x%llx  %d\n", (unsigned long long) printtri.tri,
            printtri.orient);
   }
   decode(s->ss[7], printtri);
   if (printtri.tri == m->dummytri) {
     printf("    [7] = Outer space\n");
   } else {
-    printf("    [7] = x%lx  %d\n", (unsigned long long) printtri.tri,
+    printf("    [7] = x%llx  %d\n", (unsigned long long) printtri.tri,
            printtri.orient);
   }
 
@@ -1556,14 +1556,14 @@ void printsubseg(struct mesh *m, struct behavior *b, struct osub *s)
   if (printvertex == (vertex) NULL)
     printf("    Segment origin[%d] = NULL\n", 4 + s->ssorient);
   else
-    printf("    Segment origin[%d] = x%lx  (%.12g, %.12g)\n",
+    printf("    Segment origin[%d] = x%llx  (%.12g, %.12g)\n",
            4 + s->ssorient, (unsigned long long) printvertex,
            printvertex[0], printvertex[1]);
   segdest(*s, printvertex);
   if (printvertex == (vertex) NULL)
     printf("    Segment dest  [%d] = NULL\n", 5 - s->ssorient);
   else
-    printf("    Segment dest  [%d] = x%lx  (%.12g, %.12g)\n",
+    printf("    Segment dest  [%d] = x%llx  (%.12g, %.12g)\n",
            5 - s->ssorient, (unsigned long long) printvertex,
            printvertex[0], printvertex[1]);
 }


### PR DESCRIPTION
This PR changes the printing format of the `unsigned long long` messages to avoid warning messages.